### PR TITLE
Make fails: CLOCK_MONOTONIC does not available in OSX. check_common.c…

### DIFF
--- a/perf/Makefile.am
+++ b/perf/Makefile.am
@@ -1,5 +1,5 @@
 
-LDADD = ../src/.libs/libpmalloc.la -lrt
+LDADD = ../src/.libs/libpmalloc.la
 
 AM_CFLAGS = -I../src
 

--- a/perf/common.c
+++ b/perf/common.c
@@ -9,12 +9,27 @@ Persistent Memory Library Example
 #include "pmalloc.h"
 #include "common.h"
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 unsigned int init_random(unsigned int seed)
 {
 	unsigned int ret = seed;
 	if (0 == seed) {
 		struct timespec ts;
-		clock_gettime(CLOCK_MONOTONIC, &ts);
+                #ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+                clock_serv_t cclock;
+                mach_timespec_t mts;
+                host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+                clock_get_time(cclock, &mts);
+                mach_port_deallocate(mach_task_self(), cclock);
+                ts.tv_sec = mts.tv_sec;
+                ts.tv_nsec = mts.tv_nsec;
+		#else
+                clock_gettime(CLOCK_MONOTONIC, &ts);
+                #endif
 		ret = (unsigned)ts.tv_nsec;
 	}
 	srand(ret);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,25 +7,25 @@ check_pmalloc_SOURCES = check_pmalloc.c check_common.c
 
 check_pmalloc_CFLAGS = -I../src @CHECK_CFLAGS@
 
-check_pmalloc_LDADD = ../src/libpmalloc.la @CHECK_LIBS@ -lrt
+check_pmalloc_LDADD = ../src/libpmalloc.la @CHECK_LIBS@
 
 check_pmrecycle_SOURCES = check_pmrecycle.c check_common.c
 
 check_pmrecycle_CFLAGS = -I../src @CHECK_CFLAGS@
 
-check_pmrecycle_LDADD = ../src/libpmalloc.la @CHECK_LIBS@ -lrt
+check_pmrecycle_LDADD = ../src/libpmalloc.la @CHECK_LIBS@
 
 check_pmclear_SOURCES = check_pmclear.c check_common.c
 
 check_pmclear_CFLAGS = -I../src @CHECK_CFLAGS@
 
-check_pmclear_LDADD = ../src/libpmalloc.la @CHECK_LIBS@ -lrt 
+check_pmclear_LDADD = ../src/libpmalloc.la @CHECK_LIBS@
 
 check_pmsimulate_SOURCES = check_pmsimulate.c check_common.c
 
 check_pmsimulate_CFLAGS = -I../src @CHECK_CFLAGS@
 
-check_pmsimulate_LDADD = ../src/libpmalloc.la @CHECK_LIBS@ -lrt 
+check_pmsimulate_LDADD = ../src/libpmalloc.la @CHECK_LIBS@
 
 clean-local:
 	rm -f *.data *.dat

--- a/tests/check_common.c
+++ b/tests/check_common.c
@@ -9,10 +9,25 @@ Persistent Memory Library Tests
 #include "pmalloc.h"
 #include "check_common.h"
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
 void init_random() 
 {
     struct timespec ts;
+    #ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+    ts.tv_sec = mts.tv_sec;
+    ts.tv_nsec = mts.tv_nsec;
+    #else
     clock_gettime(CLOCK_MONOTONIC, &ts);
+    #endif
     srand((unsigned)ts.tv_nsec);
 }
 


### PR DESCRIPTION
… and common.c should handle CLOCK_MONOTONIC porting for MAC
